### PR TITLE
Drop-in encoder plugins

### DIFF
--- a/binlog/reader.go
+++ b/binlog/reader.go
@@ -137,7 +137,7 @@ func (b *reader) pushSchema(t *table) bool {
 func (b *reader) addNewTable(st state.Type, i int) bool {
 	t := st[i]
 
-	enc, err := encoder.Create(encoder.TypeFromStr(b.outputFormat), t.Service, t.Db, t.Table)
+	enc, err := encoder.Create(b.outputFormat, t.Service, t.Db, t.Table)
 	if log.EL(b.log, err) {
 		return false
 	}

--- a/binlog/reader_test.go
+++ b/binlog/reader_test.go
@@ -447,7 +447,7 @@ func initConsumeTableEvents(p pipe.Pipe, db string, table string, t *testing.T) 
 }
 
 func consumeTableEvents(pc pipe.Consumer, db string, table string, result []types.CommonFormatEvent, t *testing.T) {
-	enc, err := encoder.Create(encoder.Common, "test_svc1", db, table)
+	enc, err := encoder.Create("json", "test_svc1", db, table)
 	test.CheckFail(err, t)
 
 	for i, v := range result {

--- a/snapshot/reader_test.go
+++ b/snapshot/reader_test.go
@@ -82,7 +82,7 @@ func TestEmptyTable(t *testing.T) {
 	}()
 
 	s := Reader{}
-	enc, err := encoder.Create(encoder.Common, "snap_test_svc1", "snap_test_db1", "snap_test_t1")
+	enc, err := encoder.Create("json", "snap_test_svc1", "snap_test_db1", "snap_test_t1")
 	test.CheckFail(err, t)
 
 	_, err = s.Prepare("snap_test_cluster1", "snap_test_svc1", "snap_test_db1", "snap_test_t1", enc)
@@ -120,7 +120,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	s := Reader{}
-	enc, err := encoder.Create(encoder.Common, "snap_test_svc1", "snap_test_db1", "snap_test_t1")
+	enc, err := encoder.Create("json", "snap_test_svc1", "snap_test_db1", "snap_test_t1")
 	test.CheckFail(err, t)
 
 	_, err = s.Prepare("snap_test_cluster1", "snap_test_svc1", "snap_test_db1", "snap_test_t1", enc)
@@ -188,10 +188,10 @@ func TestMoreFieldTypes(t *testing.T) {
 	ExecSQL(conn, t, "insert into snap_test_t1 values(?,?,?,?,?,?,?,?,?,?,?)", 1567, strconv.Itoa(1567), float64(1567)/3, "testtextfield", time.Now(), time.Now(), time.Now(), time.Now(), 98878, []byte("testbinaryfield"), 827738)
 
 	s := Reader{}
-	enc, err := encoder.Create(encoder.Common, "snap_test_svc1", "snap_test_db1", "snap_test_t1")
+	enc, err := encoder.Create("json", "snap_test_svc1", "snap_test_db1", "snap_test_t1")
 	test.CheckFail(err, t)
 
-	err = enc.(*encoder.CommonFormatEncoder).UpdateCodecFromDB()
+	err = encoder.CommonFormatUpdateCodecFromDB(enc)
 	test.CheckFail(err, t)
 
 	_, err = s.Prepare("snap_test_cluster1", "snap_test_svc1", "snap_test_db1", "snap_test_t1", enc)
@@ -234,7 +234,7 @@ func TestSnapshotConsistency(t *testing.T) {
 	ExecSQL(conn, t, "delete from snap_test_t1 where f1 > 300 && f1 < 400")
 
 	s := Reader{}
-	enc, err := encoder.Create(encoder.Common, "snap_test_svc1", "snap_test_db1", "snap_test_t1")
+	enc, err := encoder.Create("json", "snap_test_svc1", "snap_test_db1", "snap_test_t1")
 	test.CheckFail(err, t)
 	_, err = s.Prepare("snap_test_cluster1", "snap_test_svc1", "snap_test_db1", "snap_test_t1", enc)
 	test.CheckFail(err, t)

--- a/streamer/buffer.go
+++ b/streamer/buffer.go
@@ -66,7 +66,7 @@ func (s *Streamer) encodeCommonFormat(data []byte) (key string, outMsg []byte, e
 		}
 
 		key = encoder.GetCommonFormatKey(cfEvent)
-	} else if encoder.TypeFromStr(cfEvent.Type) == s.outputFormat {
+	} else if cfEvent.Type == s.outputFormat {
 		_, err = buf.ReadFrom(dec.Buffered())
 		if log.EL(s.log, err) {
 			return
@@ -92,7 +92,7 @@ func (s *Streamer) encodeCommonFormat(data []byte) (key string, outMsg []byte, e
 
 		key = encoder.GetCommonFormatKey(ev)
 	} else {
-		err = fmt.Errorf("Unsupported conversion from: %v to %v", cfEvent.Type, encoder.StrFromType(s.outputFormat))
+		err = fmt.Errorf("Unsupported conversion from: %v to %v", cfEvent.Type, s.outputFormat)
 	}
 
 	return

--- a/streamer/snapshot.go
+++ b/streamer/snapshot.go
@@ -23,7 +23,6 @@ package streamer
 import (
 	"time"
 
-	"github.com/uber/storagetapper/encoder"
 	"github.com/uber/storagetapper/log"
 	"github.com/uber/storagetapper/metrics"
 	"github.com/uber/storagetapper/pipe"
@@ -86,7 +85,7 @@ func (s *Streamer) commitWithRetry(snapshotMetrics *metrics.Snapshot) bool {
 }
 
 func (s *Streamer) pushSchema() bool {
-	if s.encoder.Type() == encoder.Common {
+	if s.encoder.Type() == "json" {
 		outMsg, err := s.encoder.Row(types.Schema, nil, 0)
 		if log.EL(s.log, err) {
 			return false
@@ -115,7 +114,7 @@ func (s *Streamer) streamFromConsistentSnapshot(concurrent bool, throttleMB int6
 		defer func() { log.EL(s.log, s.outPipe.CloseProducer(outProducer)) }()
 	}
 
-	s.log.Infof("Starting consistent snapshot streamer for: %v, %v concurrent: %v", s.topic, encoder.StrFromType(s.encoder.Type()), concurrent)
+	s.log.Infof("Starting consistent snapshot streamer for: %v, %v concurrent: %v", s.topic, s.encoder.Type(), concurrent)
 
 	//For JSON format push schema as a first message of the stream
 	if !s.pushSchema() {

--- a/streamer/streamer.go
+++ b/streamer/streamer.go
@@ -58,7 +58,7 @@ type Streamer struct {
 	BytesWritten int64
 	BytesRead    int64
 
-	outputFormat       int
+	outputFormat       string
 	stateUpdateTimeout int
 	batchSize          int
 	lock               lock.Lock
@@ -203,7 +203,7 @@ func (s *Streamer) start(cfg *config.AppConfig, inPipe pipe.Pipe, outPipe pipe.P
 	}
 	defer func() { log.EL(s.log, outPipe.CloseProducer(s.outProducer)) }()
 
-	s.outputFormat = encoder.TypeFromStr(cfg.OutputFormat)
+	s.outputFormat = cfg.OutputFormat
 	s.stateUpdateTimeout = cfg.StateUpdateTimeout
 
 	s.encoder, err = encoder.Create(s.outputFormat, s.svc, s.db, s.table)


### PR DESCRIPTION
No code modification required outside of the plugin file itself, when adding new
plugin.

Unneeded plugins can be removed by just removing plugin file and recompile.