### PR TITLE
Add msgpack encoder, add DecodeToCommonFormat to enc interface, add enc tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,8 @@ type AppConfig struct {
 
 	DataDir     string `yaml:"data_dir"`
 	MaxFileSize int64  `yaml:"max_file_size"`
+
+	EncoderType string `yaml:"encoder_type"`
 }
 
 // GetDefaultConfig returns default configuration
@@ -89,6 +91,8 @@ func GetDefaultConfig() *AppConfig {
 
 		DataDir:     "/var/lib/" + types.MySvcName,
 		MaxFileSize: 1024 * 1024 * 1024,
+
+		EncoderType: "json",
 	}
 }
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -11,3 +11,4 @@ state_update_timeout: 10
 state_connect_url: "root@localhost"
 kafka_addresses:
     - "localhost:9092"
+

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoder
+
+import (
+	"database/sql"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/uber/storagetapper/config"
+	"github.com/uber/storagetapper/db"
+	"github.com/uber/storagetapper/log"
+	"github.com/uber/storagetapper/state"
+	"github.com/uber/storagetapper/test"
+	"github.com/uber/storagetapper/types"
+	"github.com/uber/storagetapper/util"
+)
+
+var cfg *config.AppConfig
+var testServ = "test_svc1"
+var testDB = "db1"
+var testTable = "t1"
+
+var encoderTypes = []string{
+	"json",
+	"msgpack",
+	// TODO: "avro", Seems like avro needs some different setup to run these
+}
+
+var testBasicResult = []types.CommonFormatEvent{
+	/* Test basic insert, update, delete */
+	{Type: "insert", Key: []interface{}{1.0}, SeqNo: 1.0, Timestamp: 0, Fields: &[]types.CommonFormatField{{Name: "f1", Value: 1.0}}},
+	{Type: "insert", Key: []interface{}{2.0}, SeqNo: 2.0, Timestamp: 0, Fields: &[]types.CommonFormatField{{Name: "f1", Value: 2.0}}},
+	{Type: "delete", Key: []interface{}{2.0}, SeqNo: 3.0, Timestamp: 0, Fields: nil},
+	{Type: "insert", Key: []interface{}{12.0}, SeqNo: 4.0, Timestamp: 0, Fields: &[]types.CommonFormatField{{Name: "f1", Value: 12.0}}},
+	{Type: "delete", Key: []interface{}{1.0}, SeqNo: 5.0, Timestamp: 0, Fields: nil},
+	{Type: "insert", Key: []interface{}{3.0}, SeqNo: 6.0, Timestamp: 0, Fields: &[]types.CommonFormatField{{Name: "f1", Value: 3.0}}},
+}
+
+var testErrorDecoding = [][]byte{
+	[]byte("123234"),
+	[]byte("1231224212324132"),
+	[]byte("asdfasdcasfa"),
+}
+
+var testBasicPrepare = []string{
+	"drop database if exists db1",
+	"create database if not exists db1",
+	"drop database if exists db2",
+	"create database if not exists db2",
+
+	`create table db1.t1 (
+		f1 bigint not null primary key
+	)`,
+	`create table db2.t1 (
+		f1 bigint not null primary key
+	)`,
+}
+
+// TestGetType tests basic type method
+func TestType(t *testing.T) {
+	Prepare(t, testBasicPrepare)
+
+	for _, encType := range encoderTypes {
+		enc, err := Create(encType, testServ, testDB, testTable)
+		test.CheckFail(err, t)
+		test.Assert(t, enc.Type() == encType, "type diff")
+	}
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	Prepare(t, testBasicPrepare)
+
+	for _, encType := range encoderTypes {
+		defaultEncoderType = encType
+
+		for _, cf := range testBasicResult {
+			log.Debugf("Initial CF: %v\n", cf)
+			encoded, err := CommonFormatEncode(&cf)
+			test.CheckFail(err, t)
+
+			decoded, err := DecodeToCommonFormat(encoded)
+			log.Debugf("Post CF: %v\n", decoded)
+			test.CheckFail(err, t)
+
+			test.Assert(t, reflect.DeepEqual(&cf, decoded), "decoded different from initial")
+		}
+	}
+}
+
+func TestUnmarshalError(t *testing.T) {
+	Prepare(t, testBasicPrepare)
+
+	for _, encType := range encoderTypes {
+		defaultEncoderType = encType
+
+		for _, encoded := range testErrorDecoding {
+			_, err := DecodeToCommonFormat(encoded)
+			test.Assert(t, err != nil, "not getting an error from garbage input")
+		}
+	}
+
+}
+
+//TODO: add test to ensure bad connection gives error and not panic in create
+
+func ExecSQL(db *sql.DB, t *testing.T, query string) {
+	test.CheckFail(util.ExecSQL(db, query), t)
+}
+
+func Prepare(t *testing.T, create []string) {
+	test.SkipIfNoMySQLAvailable(t)
+
+	dbc, err := db.OpenService(&db.Loc{Cluster: "test_cluster1", Service: "test_svc1"}, "")
+	test.CheckFail(err, t)
+
+	ExecSQL(dbc, t, "RESET MASTER")
+	ExecSQL(dbc, t, "SET GLOBAL binlog_format = 'ROW'")
+	ExecSQL(dbc, t, "SET GLOBAL server_id=1")
+	ExecSQL(dbc, t, "DROP TABLE IF EXISTS "+types.MyDbName+".state")
+	ExecSQL(dbc, t, "DROP TABLE IF EXISTS "+types.MyDbName+".columns")
+
+	log.Debugf("Preparing database")
+	if !state.Init(cfg) {
+		t.FailNow()
+	}
+
+	for _, s := range create {
+		ExecSQL(dbc, t, s)
+	}
+
+	if !state.RegisterTable(&db.Loc{Cluster: "test_cluster1", Service: "test_svc1", Name: "db1"}, "t1", "mysql", "") {
+		t.FailNow()
+	}
+}
+
+func TestMain(m *testing.M) {
+	cfg = test.LoadConfig()
+	os.Exit(m.Run())
+}

--- a/encoder/msgpack.go
+++ b/encoder/msgpack.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoder
+
+import (
+	"github.com/uber/storagetapper/types"
+)
+
+func init() {
+	registerPlugin("msgpack", initMsgPackEncoder)
+}
+
+// msgPackEncoder implements Encoder interface into message pack format.
+// It inherits the methods from commonFormatEnocder.
+type msgPackEncoder struct {
+	c commonFormatEncoder
+}
+
+func initMsgPackEncoder(service string, db string, table string) (Encoder, error) {
+	return &msgPackEncoder{c: commonFormatEncoder{Service: service, Db: db, Table: table}}, nil
+}
+
+//Schema returns table schema
+func (e *msgPackEncoder) Schema() *types.TableSchema {
+	return e.c.inSchema
+}
+
+//Row encodes row into CommonFormat
+func (e *msgPackEncoder) Row(tp int, row *[]interface{}, seqno uint64) ([]byte, error) {
+	cf := e.c.convertRowToCommonFormat(tp, row, e.c.inSchema, seqno, e.c.filter)
+	return e.CommonFormatEncode(cf)
+}
+
+/*UpdateCodec refreshes the schema from state DB */
+func (e *msgPackEncoder) UpdateCodec() error {
+	return e.c.UpdateCodec()
+}
+
+//CommonFormat encodes common format event into byte array
+func (e *msgPackEncoder) CommonFormat(cf *types.CommonFormatEvent) ([]byte, error) {
+	if cf.Type == "schema" {
+		err := e.c.UpdateCodec()
+		if err != nil {
+			return nil, err
+		}
+	}
+	//FIXME: Assume that cf is in input schema format, so we need to filter it
+	//to conform to output schema
+	return e.CommonFormatEncode(cf)
+}
+
+//Type returns this encoder type
+func (e *msgPackEncoder) Type() string {
+	return "msgpack"
+}
+
+// CommonFormatEncode encodes CommonFormatEvent into byte array based on the message pack
+// encoding system
+// By overriding these 2 methods we get full functionality of commonFormatEncoder
+// that implements MessagePack
+func (e *msgPackEncoder) CommonFormatEncode(c *types.CommonFormatEvent) ([]byte, error) {
+	return c.MarshalMsg(nil)
+	// return msgpack.Marshal(c)
+}
+
+// CommonFormatDecode decodes CommonFormatEvent from byte array based on the msgpack encoding system
+func (e *msgPackEncoder) CommonFormatDecode(b []byte) (*types.CommonFormatEvent, error) {
+	res := &types.CommonFormatEvent{}
+	_, err := res.UnmarshalMsg(b)
+	return res, err
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 97fb5538e4f9eaf1e3ce4eaf6f6ac8f99d0402c16ad24fcf3c68ce5a393bf158
-updated: 2017-05-14T21:50:38.396697025-07:00
+hash: 683726802147f81737c1155b3e2ed039d816e1053bcd8c91b33e6453e8c8df11
+updated: 2017-06-06T00:58:35.062102311Z
 imports:
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 1139cdac1a56e404b5382e3a3503a2c587d2c0c3
   subpackages:
   - statsd
 - name: github.com/davecgh/go-spew
@@ -10,37 +10,43 @@ imports:
   subpackages:
   - spew
 - name: github.com/eapache/go-resiliency
-  version: ed0319b32e66e3295db52695ba3ee493e823fbfe
+  version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
   subpackages:
   - breaker
 - name: github.com/eapache/go-xerial-snappy
   version: bb955e01b9346ac19dc29eb16586c90ded99a98c
 - name: github.com/eapache/queue
-  version: d1df561eb6b9ffdac8dd98f943e9e9096c76c059
+  version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/go-sql-driver/mysql
   version: a0583e0143b1624142adab07e0e97fe106d99561
+- name: github.com/golang/protobuf
+  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+  subpackages:
+  - proto
 - name: github.com/golang/snappy
-  version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
+  version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/juju/errors
   version: 6f54ff6318409d31ff16261533ce2c8381a4fd5d
 - name: github.com/klauspost/crc32
-  version: cb6bfca970f6908083f26f39a79009d608efd5cd
+  version: 1bab8b35b6bb565f92cbc97939610af9369f942a
 - name: github.com/linkedin/goavro
   version: 44e21733ba10332b88303373cac586154316aa5c
 - name: github.com/ngaut/log
   version: cec23d3e10b016363780d894a0eb732a12c06e02
+- name: github.com/philhofer/fwd
+  version: 98c11a7a6ec829d672b03833c3d69a7fae1ca972
 - name: github.com/pierrec/lz4
-  version: f5b77fd73d83122495309c0f459b810f83cc291f
+  version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
 - name: github.com/pierrec/xxHash
   version: 5a004441f897722c627870a981d02b29924215fa
   subpackages:
   - xxHash32
 - name: github.com/rcrowley/go-metrics
-  version: eeba7bd0dd01ace6e690fa833b3f22aaec29af43
+  version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/Shopify/sarama
   version: 0fb560e5f7fbcaee2f75e3c34174320709f69944
 - name: github.com/siddontang/go
@@ -50,16 +56,20 @@ imports:
   - ioutil2
   - sync2
 - name: github.com/siddontang/go-mysql
-  version: fbb2f2f74678817ea49bfde307583242aea6edd2
+  version: e83b1664b8fc96202159841d0a1306160fc3f859
   subpackages:
   - client
   - mysql
   - packet
   - replication
 - name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: 5e5dc898656f695e2a086b8e12559febbfc01562
+- name: github.com/tinylib/msgp
+  version: 02d047e07459c5a7b02b1244161d0f2f6d8f660d
+  subpackages:
+  - msgp
 - name: github.com/uber-common/bark
-  version: 1276fd80f25d786f9cff3ccce89c0c43e5b2667e
+  version: 148dd9dfbd0feb293fc81593a8c10c99877f81bc
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/zap
@@ -72,13 +82,28 @@ imports:
   - internal/multierror
   - zapcore
 - name: golang.org/x/net
-  version: 6acef71eb69611914f7a30939ea9f6e194c78172
+  version: 59a0b19b5533c7977ddeb86b017bf507ed407b12
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: b90f89a1e7a9c1f6b918820b3daa7f08488c8594
   subpackages:
   - unix
+- name: google.golang.org/appengine
+  version: a2f4131514e563cedfdb6e7d267df9ad48591e93
+  subpackages:
+  - datastore
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+- name: gopkg.in/vmihailenco/msgpack.v2
+  version: f4f8982de4ef0de18be76456617cc3f5d8d8141e
+  subpackages:
+  - codes
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,4 @@ import:
   version: 1.4.2
 - package: go.uber.org/zap
   version: 1.4.0
+- package: gopkg.in/vmihailenco/msgpack.v2

--- a/main_test.go
+++ b/main_test.go
@@ -141,8 +141,9 @@ func consumeEvents(c pipe.Consumer, format string, avroResult []string, jsonResu
 
 		//		log.Errorf("Received : %+v %v", string(b), len(b))
 		//		log.Errorf("Reference: %+v %v", v, len(v))
-		if v != string(b) {
-			log.Errorf("Received : %+v %v", string(b), len(b))
+		conv := string(b)
+		if v != conv {
+			log.Errorf("Received : %+v %v", conv, len(b))
 			log.Errorf("Reference: %+v %v", v, len(v))
 			t.FailNow()
 		}

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 TIMEOUT=300s
 
-CGO_ENABLED=0 gometalinter --deadline=$TIMEOUT --disable-all -Evet -Egolint -Egoimports -Eineffassign -Egosimple -Eerrcheck -Eunused -Edeadcode -Emisspell -Egocyclo --cyclo-over=15 $@
+CGO_ENABLED=0 gometalinter -e format_gen --deadline=$TIMEOUT --disable-all -Evet -Egolint -Egoimports -Eineffassign -Egosimple -Eerrcheck -Eunused -Edeadcode -Emisspell -Egocyclo --cyclo-over=15 $@

--- a/types/format.go
+++ b/types/format.go
@@ -20,6 +20,8 @@
 
 package types
 
+//go:generate msgp
+
 //CommonFormatEvent types
 const (
 	Insert int = iota

--- a/types/format_gen.go
+++ b/types/format_gen.go
@@ -1,0 +1,500 @@
+package types
+
+// nolint
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *CommonFormatEvent) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zbai uint32
+	zbai, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zbai > 0 {
+		zbai--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Type":
+			z.Type, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Key":
+			var zcmr uint32
+			zcmr, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Key) >= int(zcmr) {
+				z.Key = (z.Key)[:zcmr]
+			} else {
+				z.Key = make([]interface{}, zcmr)
+			}
+			for zxvk := range z.Key {
+				z.Key[zxvk], err = dc.ReadIntf()
+				if err != nil {
+					return
+				}
+			}
+		case "SeqNo":
+			z.SeqNo, err = dc.ReadUint64()
+			if err != nil {
+				return
+			}
+		case "Timestamp":
+			z.Timestamp, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		case "Fields":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					return
+				}
+				z.Fields = nil
+			} else {
+				if z.Fields == nil {
+					z.Fields = new([]CommonFormatField)
+				}
+				var zajw uint32
+				zajw, err = dc.ReadArrayHeader()
+				if err != nil {
+					return
+				}
+				if cap(*z.Fields) >= int(zajw) {
+					*z.Fields = (*z.Fields)[:zajw]
+				} else {
+					*z.Fields = make([]CommonFormatField, zajw)
+				}
+				for zbzg := range *z.Fields {
+					var zwht uint32
+					zwht, err = dc.ReadMapHeader()
+					if err != nil {
+						return
+					}
+					for zwht > 0 {
+						zwht--
+						field, err = dc.ReadMapKeyPtr()
+						if err != nil {
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "Name":
+							(*z.Fields)[zbzg].Name, err = dc.ReadString()
+							if err != nil {
+								return
+							}
+						case "Value":
+							(*z.Fields)[zbzg].Value, err = dc.ReadIntf()
+							if err != nil {
+								return
+							}
+						default:
+							err = dc.Skip()
+							if err != nil {
+								return
+							}
+						}
+					}
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *CommonFormatEvent) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 5
+	// write "Type"
+	err = en.Append(0x85, 0xa4, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Type)
+	if err != nil {
+		return
+	}
+	// write "Key"
+	err = en.Append(0xa3, 0x4b, 0x65, 0x79)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Key)))
+	if err != nil {
+		return
+	}
+	for zxvk := range z.Key {
+		err = en.WriteIntf(z.Key[zxvk])
+		if err != nil {
+			return
+		}
+	}
+	// write "SeqNo"
+	err = en.Append(0xa5, 0x53, 0x65, 0x71, 0x4e, 0x6f)
+	if err != nil {
+		return err
+	}
+	err = en.WriteUint64(z.SeqNo)
+	if err != nil {
+		return
+	}
+	// write "Timestamp"
+	err = en.Append(0xa9, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.Timestamp)
+	if err != nil {
+		return
+	}
+	// write "Fields"
+	err = en.Append(0xa6, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x73)
+	if err != nil {
+		return err
+	}
+	if z.Fields == nil {
+		err = en.WriteNil()
+		if err != nil {
+			return
+		}
+	} else {
+		err = en.WriteArrayHeader(uint32(len(*z.Fields)))
+		if err != nil {
+			return
+		}
+		for zbzg := range *z.Fields {
+			// map header, size 2
+			// write "Name"
+			err = en.Append(0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+			if err != nil {
+				return err
+			}
+			err = en.WriteString((*z.Fields)[zbzg].Name)
+			if err != nil {
+				return
+			}
+			// write "Value"
+			err = en.Append(0xa5, 0x56, 0x61, 0x6c, 0x75, 0x65)
+			if err != nil {
+				return err
+			}
+			err = en.WriteIntf((*z.Fields)[zbzg].Value)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *CommonFormatEvent) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 5
+	// string "Type"
+	o = append(o, 0x85, 0xa4, 0x54, 0x79, 0x70, 0x65)
+	o = msgp.AppendString(o, z.Type)
+	// string "Key"
+	o = append(o, 0xa3, 0x4b, 0x65, 0x79)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Key)))
+	for zxvk := range z.Key {
+		o, err = msgp.AppendIntf(o, z.Key[zxvk])
+		if err != nil {
+			return
+		}
+	}
+	// string "SeqNo"
+	o = append(o, 0xa5, 0x53, 0x65, 0x71, 0x4e, 0x6f)
+	o = msgp.AppendUint64(o, z.SeqNo)
+	// string "Timestamp"
+	o = append(o, 0xa9, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
+	o = msgp.AppendInt64(o, z.Timestamp)
+	// string "Fields"
+	o = append(o, 0xa6, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x73)
+	if z.Fields == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendArrayHeader(o, uint32(len(*z.Fields)))
+		for zbzg := range *z.Fields {
+			// map header, size 2
+			// string "Name"
+			o = append(o, 0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+			o = msgp.AppendString(o, (*z.Fields)[zbzg].Name)
+			// string "Value"
+			o = append(o, 0xa5, 0x56, 0x61, 0x6c, 0x75, 0x65)
+			o, err = msgp.AppendIntf(o, (*z.Fields)[zbzg].Value)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *CommonFormatEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zhct uint32
+	zhct, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zhct > 0 {
+		zhct--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Type":
+			z.Type, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Key":
+			var zcua uint32
+			zcua, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Key) >= int(zcua) {
+				z.Key = (z.Key)[:zcua]
+			} else {
+				z.Key = make([]interface{}, zcua)
+			}
+			for zxvk := range z.Key {
+				z.Key[zxvk], bts, err = msgp.ReadIntfBytes(bts)
+				if err != nil {
+					return
+				}
+			}
+		case "SeqNo":
+			z.SeqNo, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "Timestamp":
+			z.Timestamp, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "Fields":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Fields = nil
+			} else {
+				if z.Fields == nil {
+					z.Fields = new([]CommonFormatField)
+				}
+				var zxhx uint32
+				zxhx, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if err != nil {
+					return
+				}
+				if cap(*z.Fields) >= int(zxhx) {
+					*z.Fields = (*z.Fields)[:zxhx]
+				} else {
+					*z.Fields = make([]CommonFormatField, zxhx)
+				}
+				for zbzg := range *z.Fields {
+					var zlqf uint32
+					zlqf, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if err != nil {
+						return
+					}
+					for zlqf > 0 {
+						zlqf--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "Name":
+							(*z.Fields)[zbzg].Name, bts, err = msgp.ReadStringBytes(bts)
+							if err != nil {
+								return
+							}
+						case "Value":
+							(*z.Fields)[zbzg].Value, bts, err = msgp.ReadIntfBytes(bts)
+							if err != nil {
+								return
+							}
+						default:
+							bts, err = msgp.Skip(bts)
+							if err != nil {
+								return
+							}
+						}
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *CommonFormatEvent) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Type) + 4 + msgp.ArrayHeaderSize
+	for zxvk := range z.Key {
+		s += msgp.GuessSize(z.Key[zxvk])
+	}
+	s += 6 + msgp.Uint64Size + 10 + msgp.Int64Size + 7
+	if z.Fields == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.ArrayHeaderSize
+		for zbzg := range *z.Fields {
+			s += 1 + 5 + msgp.StringPrefixSize + len((*z.Fields)[zbzg].Name) + 6 + msgp.GuessSize((*z.Fields)[zbzg].Value)
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *CommonFormatField) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zdaf uint32
+	zdaf, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zdaf > 0 {
+		zdaf--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Value":
+			z.Value, err = dc.ReadIntf()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z CommonFormatField) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Name"
+	err = en.Append(0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Name)
+	if err != nil {
+		return
+	}
+	// write "Value"
+	err = en.Append(0xa5, 0x56, 0x61, 0x6c, 0x75, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteIntf(z.Value)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z CommonFormatField) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Name"
+	o = append(o, 0x82, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Name)
+	// string "Value"
+	o = append(o, 0xa5, 0x56, 0x61, 0x6c, 0x75, 0x65)
+	o, err = msgp.AppendIntf(o, z.Value)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *CommonFormatField) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zpks uint32
+	zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zpks > 0 {
+		zpks--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Value":
+			z.Value, bts, err = msgp.ReadIntfBytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z CommonFormatField) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 6 + msgp.GuessSize(z.Value)
+	return
+}

--- a/types/format_gen_test.go
+++ b/types/format_gen_test.go
@@ -1,0 +1,239 @@
+package types
+
+// nolint
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalCommonFormatEvent(t *testing.T) {
+	v := CommonFormatEvent{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgCommonFormatEvent(b *testing.B) {
+	v := CommonFormatEvent{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgCommonFormatEvent(b *testing.B) {
+	v := CommonFormatEvent{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalCommonFormatEvent(b *testing.B) {
+	v := CommonFormatEvent{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeCommonFormatEvent(t *testing.T) {
+	v := CommonFormatEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := CommonFormatEvent{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeCommonFormatEvent(b *testing.B) {
+	v := CommonFormatEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeCommonFormatEvent(b *testing.B) {
+	v := CommonFormatEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalCommonFormatField(t *testing.T) {
+	v := CommonFormatField{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgCommonFormatField(b *testing.B) {
+	v := CommonFormatField{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgCommonFormatField(b *testing.B) {
+	v := CommonFormatField{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalCommonFormatField(b *testing.B) {
+	v := CommonFormatField{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeCommonFormatField(t *testing.T) {
+	v := CommonFormatField{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := CommonFormatField{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeCommonFormatField(b *testing.B) {
+	v := CommonFormatField{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeCommonFormatField(b *testing.B) {
+	v := CommonFormatField{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Changed global methods in the commonFormatEncoder to be local. This ensures that all encoding is done only after creating an encoder, allowing the process to be safer. 
Changed the calls that did this to call created encoders in test files and in binlog, snapshot and streamer. 

Avro DecodeToCommonFormat has not been implemented and will throw an error if called. 