### PR TITLE
Extend the pipe interface with explicit PushSchema method

### DIFF
--- a/binlog/reader.go
+++ b/binlog/reader.go
@@ -127,8 +127,7 @@ func (b *reader) pushSchema(t *table) bool {
 		return false
 	}
 
-	//FIXME: Push to all partitions
-	err = t.producer.PushBatch("", bd)
+	err = t.producer.PushSchema("", bd)
 	log.Debugf("Pushed schema %v seqno=%v", t.id, seqno)
 
 	return !log.EL(b.log, err)

--- a/pipe/file.go
+++ b/pipe/file.go
@@ -376,6 +376,19 @@ func (p *fileProducer) PushBatchCommit() error {
 	return nil
 }
 
+func (p *fileProducer) PushSchema(key string, data []byte) error {
+	if err := p.PushBatchCommit(); err != nil {
+		return err
+	}
+	if key == "" {
+		key = "default"
+	}
+	_ = p.closeFile(p.files[key])
+	p.files[key] = nil
+
+	return p.PushK(key, data)
+}
+
 // Close File Producer
 func (p *fileProducer) Close() error {
 	var err error

--- a/pipe/kafka.go
+++ b/pipe/kafka.go
@@ -558,6 +558,10 @@ func (p *kafkaProducer) PushBatchCommit() error {
 	return err
 }
 
+func (p *kafkaProducer) PushSchema(key string, data []byte) error {
+	return p.PushBatch(key, data)
+}
+
 // Close Kafka Producer
 func (p *kafkaProducer) Close() error {
 	err := p.producer.Close()

--- a/pipe/local.go
+++ b/pipe/local.go
@@ -100,20 +100,24 @@ func (p *localProducerConsumer) pushLow(b interface{}) error {
 }
 
 //Push pushes the given message to pipe
-func (p *localProducerConsumer) Push(b interface{}) error {
-	return p.pushLow(b)
+func (p *localProducerConsumer) Push(data interface{}) error {
+	return p.pushLow(data)
 }
 
 //PushBatch stashes the given message in pipe buffer, all stashed messages will
 //be send by subsequent PushBatchCommit call
-func (p *localProducerConsumer) PushBatch(key string, b interface{}) error {
-	return p.pushLow(b)
+func (p *localProducerConsumer) PushBatch(key string, data interface{}) error {
+	return p.pushLow(data)
 }
 
 //PushBatchCommit sends all stashed messages to pipe
 func (p *localProducerConsumer) PushBatchCommit() error {
 	//TODO: Drain the channel here
 	return nil
+}
+
+func (p *localProducerConsumer) PushSchema(key string, data []byte) error {
+	return p.PushBatch(key, data)
 }
 
 //FetchNext receives next message from pipe. It's a blocking call, message can

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -43,6 +43,7 @@ type Consumer interface {
 type Producer interface {
 	Push(data interface{}) error
 	PushK(key string, data interface{}) error
+	PushSchema(key string, data []byte) error
 	//PushBatch queues the messages instead of sending immediately
 	PushBatch(key string, data interface{}) error
 	//PushCommit writes out all the messages queued by PushBatch

--- a/streamer/buffer.go
+++ b/streamer/buffer.go
@@ -60,6 +60,18 @@ func (s *Streamer) encodeCommonFormat(data []byte) (key string, outMsg []byte, e
 		}
 
 		key = encoder.GetCommonFormatKey(cfEvent)
+
+		if cfEvent.Type == "schema" && outMsg != nil {
+			if s.outPipe.Type() == "file" {
+				key = "log"
+			}
+
+			err = s.outProducer.PushSchema(key, outMsg)
+			log.EL(s.log, err)
+
+			outMsg = nil
+			return
+		}
 	} else if cfEvent.Type == s.outputFormat {
 		outMsg = payload
 		key = cfEvent.Key[0].(string)

--- a/streamer/snapshot.go
+++ b/streamer/snapshot.go
@@ -93,7 +93,7 @@ func (s *Streamer) pushSchema() bool {
 		if log.EL(s.log, err) {
 			return false
 		}
-		err = s.outProducer.Push(outMsg)
+		err = s.outProducer.PushSchema("", outMsg)
 		if log.EL(s.log, err) {
 			return false
 		}


### PR DESCRIPTION
This is useful with file pipe for example, where we want to start new file on
every schema change