### PR TITLE
Periodically save pipe offset in streamer

### DIFF
--- a/pipe/file.go
+++ b/pipe/file.go
@@ -40,6 +40,7 @@ import (
 )
 
 //TODO: Support reading file currently open by producer
+//TODO: Support offset persistence
 
 var delimiter byte = '\n'
 
@@ -538,5 +539,9 @@ func (p *fileConsumer) Close() error {
 		err := p.file.Close()
 		log.E(err)
 	}
+	return nil
+}
+
+func (p *fileConsumer) SaveOffset() error {
 	return nil
 }

--- a/pipe/kafka.go
+++ b/pipe/kafka.go
@@ -597,6 +597,13 @@ func (p *kafkaConsumer) Close() error {
 	return nil
 }
 
+func (p *kafkaConsumer) SaveOffset() error {
+	p.pipe.lock.Lock()
+	defer p.pipe.lock.Unlock()
+
+	return p.commitConsumerPartitionOffsets()
+}
+
 /*
 type saramaLogger struct {
 }

--- a/pipe/local.go
+++ b/pipe/local.go
@@ -150,3 +150,8 @@ func (p *localProducerConsumer) Close() error {
 	close(p.closeCh)
 	return nil
 }
+
+//SaveOffset is not applicable for local pipe
+func (p *localProducerConsumer) SaveOffset() error {
+	return nil
+}

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -37,6 +37,8 @@ type Consumer interface {
 	  Message and error can be later retreived by Pop call.
 	  If it returns false this means EOF and no more Pops allowed */
 	FetchNext() bool
+	//Allows to explicitly persists current consumer position
+	SaveOffset() error
 }
 
 //Producer producer interface for pipe

--- a/streamer/buffer.go
+++ b/streamer/buffer.go
@@ -237,6 +237,12 @@ func (s *Streamer) StreamTable(consumer pipe.Consumer, bootstrapCh chan bool) bo
 				s.log.Warnf("Table removed from ingestion")
 				return true
 			}
+
+			if err := consumer.SaveOffset(); err != nil {
+				s.log.Errorf("Error persisting pipe position")
+				return true
+			}
+
 		case err := <-bootstrapCh:
 			if err {
 				return false


### PR DESCRIPTION
This allows to not resend "offsetPersistInterval" events on restart, in the
case of infrequent writes.
This bounds the time_in_buffer metric as well.