### PR TITLE
[WIP] Better fields filtering in encoders

### DIFF
--- a/changelog/mysql.go
+++ b/changelog/mysql.go
@@ -211,7 +211,7 @@ func (b *mysqlReader) createProducer(tn string, t *state.Row) (pipe.Producer, er
 
 func (b *mysqlReader) addNewTable(t *state.Row) bool {
 	b.log.Infof("Adding table to MySQL binlog reader (%v,%v,%v,%v,%v,%v)", t.Service, t.Db, t.Table, t.Output, t.Version, t.OutputFormat)
-	enc, err := encoder.Create(t.OutputFormat, t.Service, t.Db, t.Table, t.Input, t.Output, t.Version)
+	enc, err := encoder.Create(t.OutputFormat, t.Service, t.Db, t.Table, t.Input, t.Output, t.Version, true)
 	if log.EL(b.log, err) {
 		return false
 	}

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -970,6 +970,17 @@ func TestUnwrapBinaryKey(t *testing.T) {
 	test.Assert(t, s == key, "keys should be equal")
 }
 
+func TestPrepareFilter(t *testing.T) {
+	var tests = struct {
+		in     []types.ColumnSchema
+		out    []types.AvroFields
+		result []int
+	}{
+		in:  []types.ColumnSchema{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+		out: []types.AvroFields{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+	}
+}
+
 func ExecSQL(db *sql.DB, t test.Failer, query string) {
 	test.CheckFail(util.ExecSQL(db, query), t)
 }

--- a/encoder/z.go
+++ b/encoder/z.go
@@ -36,7 +36,7 @@ import (
 
 func init() {
 	var err error
-	Internal, err = InitEncoder(config.Get().InternalEncoding, "", "", "", "", "", 0)
+	Internal, err = InitEncoder(config.Get().InternalEncoding, "", "", "", "", "", 0, true)
 	if err != nil {
 		panic(fmt.Sprintf("Set InternalEncoding to json. Error: %s", err.Error()))
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -193,6 +193,8 @@ func consumeEvents(c pipe.Consumer, format string, result []string, outEncoder e
 			log.Errorf("Received : %+v %v", conv, len(b))
 			log.Errorf("Reference: %+v %v", v, len(v))
 			t.FailNow()
+		} else {
+			log.Debugf("Successfully matched : %+v %v", conv, len(b))
 		}
 		log.Debugf("Successfully matched: %+v %v", conv, len(b))
 	}
@@ -213,6 +215,8 @@ func waitAllEventsStreamed(format string, c pipe.Consumer, sseqno int, seqno int
 	for ; sseqno < seqno; sseqno++ {
 		_ = c.FetchNext()
 	}
+
+	log.Debugf("Events streamed upto seqno=%v", sseqno)
 
 	return sseqno
 }
@@ -364,7 +368,7 @@ func testStep(inPipeType string, bufferFormat string, outPipeType string, outPip
 	if outPipeFormat == "json" || outPipeFormat == "msgpack" {
 		cfg.InternalEncoding = outPipeFormat
 		var err error
-		encoder.Internal, err = encoder.InitEncoder(cfg.InternalEncoding, "", "", "", "", "", 0)
+		encoder.Internal, err = encoder.InitEncoder(cfg.InternalEncoding, "", "", "", "", "", 0, true)
 		require.NoError(t, err)
 	}
 
@@ -424,7 +428,7 @@ func testStep(inPipeType string, bufferFormat string, outPipeType string, outPip
 	addTable(outPipeFormat, "1", outPipeType, t)
 
 	// Encoder/decoder for the table added above
-	outEncoder, err := encoder.Create(outPipeFormat, "e2e_test_svc1", "e2e_test_db1", "e2e_test_table1", "mysql", outPipeType, 0)
+	outEncoder, err := encoder.Create(outPipeFormat, "e2e_test_svc1", "e2e_test_db1", "e2e_test_table1", "mysql", outPipeType, 0, true)
 	require.NoError(t, err)
 
 	// Wait snapshot to finish before sending more data otherwise everything even following events will be read
@@ -464,7 +468,7 @@ func testStep(inPipeType string, bufferFormat string, outPipeType string, outPip
 	addTable(outPipeFormat, "2", outPipeType, t)
 
 	// Encoder/decoder for the table added above
-	outEncoder2, err := encoder.Create(outPipeFormat, "e2e_test_svc1", "e2e_test_db1", "e2e_test_table2", "mysql", outPipeType, 0)
+	outEncoder2, err := encoder.Create(outPipeFormat, "e2e_test_svc1", "e2e_test_db1", "e2e_test_table2", "mysql", outPipeType, 0, true)
 	require.NoError(t, err)
 
 	// Wait snapshot to finish before sending more data otherwise everything even following events will be read

--- a/streamer/streamer.go
+++ b/streamer/streamer.go
@@ -273,7 +273,7 @@ func (s *Streamer) start(cfg *config.AppConfig) bool {
 		return false
 	}
 
-	s.outEncoder, err = encoder.Create(s.row.OutputFormat, s.row.Service, s.row.Db, s.row.Table, s.row.Input, s.row.Output, s.row.Version)
+	s.outEncoder, err = encoder.Create(s.row.OutputFormat, s.row.Service, s.row.Db, s.row.Table, s.row.Input, s.row.Output, s.row.Version, !cfg.ChangelogBuffer)
 	if log.EL(s.log, err) {
 		if consumer != nil {
 			log.E(consumer.CloseOnFailure())
@@ -293,7 +293,7 @@ func (s *Streamer) start(cfg *config.AppConfig) bool {
 	if cfg.ChangelogBuffer {
 		//Transit format encoder, aka envelope encoder
 		//It must be per table to be able to decode schematized events
-		s.envEncoder, err = encoder.Create(encoder.Internal.Type(), s.row.Service, s.row.Db, s.row.Table, s.row.Input, s.row.Output, s.row.Version)
+		s.envEncoder, err = encoder.Create(encoder.Internal.Type(), s.row.Service, s.row.Db, s.row.Table, s.row.Input, s.row.Output, s.row.Version, true)
 		if log.EL(s.log, err) {
 			log.E(consumer.CloseOnFailure())
 			return false


### PR DESCRIPTION
Currently output schema can only less fields than input schema, meaning we can only filter fields from input schema. If it happens that input schema has less fields, for example, column is dropped in the source table, then it'll brake ingestion.

The idea behind this diff is to make filtering more generic and allow to filter both input and output schema columns.